### PR TITLE
Build fix in shipping configuration

### DIFF
--- a/MultiViewRendering/Source/MultiViewRendering/MultiViewRendering.cpp
+++ b/MultiViewRendering/Source/MultiViewRendering/MultiViewRendering.cpp
@@ -1,22 +1,27 @@
 #include "MultiViewRendering.h"
 #include "Engine/MultiViewRenderingSettings.h"
+#if WITH_EDITOR
 #include "ISettingsModule.h"
 #include "ISettingsSection.h"
 #include "ISettingsContainer.h"
-
+#endif
 #define LOCTEXT_NAMESPACE "FMultiViewRenderingModule"
 
 void FMultiViewRenderingModule::StartupModule()
 {
+#if WITH_EDITOR
 	RegisterSettings();
+#endif
 }
 
 void FMultiViewRenderingModule::ShutdownModule()
 {
+#if WITH_EDITOR
 	if (UObjectInitialized())
 	{
 		UnregisterSettings();
 	}
+#endif
 }
 
 bool FMultiViewRenderingModule::SupportsDynamicReloading()
@@ -26,6 +31,7 @@ bool FMultiViewRenderingModule::SupportsDynamicReloading()
 
 bool FMultiViewRenderingModule::HandleSettingsSaved()
 {
+#if WITH_EDITOR
 	UMultiViewRenderingSettings* Settings = GetMutableDefault<UMultiViewRenderingSettings>();
 	bool ResaveSettings = false;
 
@@ -36,12 +42,13 @@ bool FMultiViewRenderingModule::HandleSettingsSaved()
 	{
 		Settings->SaveConfig();
 	}
-
+#endif
 	return true;
 }
 
 void FMultiViewRenderingModule::RegisterSettings()
 {
+#if WITH_EDITOR
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
 		// Create the new category
@@ -65,16 +72,19 @@ void FMultiViewRenderingModule::RegisterSettings()
 			SettingsSection->OnModified().BindRaw(this, &FMultiViewRenderingModule::HandleSettingsSaved);
 		}
 	}
+#endif
 }
 
 void FMultiViewRenderingModule::UnregisterSettings()
 {
+#if WITH_EDITOR
 	// Ensure to unregister all of your registered settings here, hot-reload would
 	// otherwise yield unexpected results.
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
 		SettingsModule->UnregisterSettings("Project", "MVR", "General");
 	}
+#endif
 }
 
 #undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
Never tried a shipping build, just tested if the project can be built. So in the current state this might not be relevant yet.

General feedback using 4.22.2:
Was trying out your plugin in editor.
- PIE in editor window does not render triple screen, resizing works.
- Resizing window in standalone PIE window was called, but directly overwritten by MoviePlayer window resize calls. So had to call the SetupTripleScreenWindow() function with some delay from an ActorClass to make it work. Happy to see three views being rendered! :-)