### PR TITLE
Build fix

### DIFF
--- a/MultiViewRendering/Source/MultiViewRendering/MultiViewRendering.cpp
+++ b/MultiViewRendering/Source/MultiViewRendering/MultiViewRendering.cpp
@@ -1,22 +1,27 @@
 #include "MultiViewRendering.h"
 #include "Engine/MultiViewRenderingSettings.h"
+#if WITH_EDITOR
 #include "ISettingsModule.h"
 #include "ISettingsSection.h"
 #include "ISettingsContainer.h"
-
+#endif
 #define LOCTEXT_NAMESPACE "FMultiViewRenderingModule"
 
 void FMultiViewRenderingModule::StartupModule()
 {
+#if WITH_EDITOR
 	RegisterSettings();
+#endif
 }
 
 void FMultiViewRenderingModule::ShutdownModule()
 {
+#if WITH_EDITOR
 	if (UObjectInitialized())
 	{
 		UnregisterSettings();
 	}
+#endif
 }
 
 bool FMultiViewRenderingModule::SupportsDynamicReloading()
@@ -26,6 +31,7 @@ bool FMultiViewRenderingModule::SupportsDynamicReloading()
 
 bool FMultiViewRenderingModule::HandleSettingsSaved()
 {
+#if WITH_EDITOR
 	UMultiViewRenderingSettings* Settings = GetMutableDefault<UMultiViewRenderingSettings>();
 	bool ResaveSettings = false;
 
@@ -36,12 +42,13 @@ bool FMultiViewRenderingModule::HandleSettingsSaved()
 	{
 		Settings->SaveConfig();
 	}
-
+#endif
 	return true;
 }
 
 void FMultiViewRenderingModule::RegisterSettings()
 {
+#if WITH_EDITOR
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
 		// Create the new category
@@ -65,16 +72,19 @@ void FMultiViewRenderingModule::RegisterSettings()
 			SettingsSection->OnModified().BindRaw(this, &FMultiViewRenderingModule::HandleSettingsSaved);
 		}
 	}
+#endif
 }
 
 void FMultiViewRenderingModule::UnregisterSettings()
 {
+#if WITH_EDITOR
 	// Ensure to unregister all of your registered settings here, hot-reload would
 	// otherwise yield unexpected results.
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
 		SettingsModule->UnregisterSettings("Project", "MVR", "General");
 	}
+#endif
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/UnrealEngine-4.22/Engine/Shaders/Private/InstancedStereo.ush
+++ b/UnrealEngine-4.22/Engine/Shaders/Private/InstancedStereo.ush
@@ -90,8 +90,10 @@ float2 ClipInstancingRendering(inout float4 Position, int EyeIndex)
 	float ViewRatio = 1.0 / View.NumViews;
 	int EyeOffsetIndexShift = 2 * (View.NumViews - 2);
 	Position.x *= ViewRatio * ResolvedView.HMDEyePaddingOffset;
+#if INSTANCED_STEREO
 	Position.x += (EyeOffsetScale[EyeOffsetIndexShift + EyeIndex] * Position.w) * (1.0f - ViewRatio * ResolvedView.HMDEyePaddingOffset);
-
+#endif
+	
 	return OutClipDistances;
 }
 // FB Bulgakov End


### PR DESCRIPTION
Tested with 4.22.2:
- PIE in editor and standalone PIE window resize works, no separate views rendered
- Standalone process launched from editor and packaged project renders three views, resize works only when delaying the SetupTripleScreen() call - the default MoviePlayer calls the resize window after the SetupTripleScreen() call from a pawn classes BeginPlay(). Not sure what to do about that engine behavior and where to better put the SetupTripleScreen() call. I also saw that even the common plugins using the IStereoRendering are running into the same behavior and move their call to a PreTick() function and cover it with a "run once" flag.

The difference between PIE and standalone has to do with the two "flow paths", like shown in the [documentation](https://docs.unrealengine.com/en-US/Gameplay/Framework/GameFlow/index.html).

Keep up the great work! Really thankful for what you provide!